### PR TITLE
fix: increase dependabot open-pull-requests-limit from 10 to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/" # ルートに package.json がある場合
     schedule:
       interval: "weekly" # or "daily" にすれば毎日更新
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     allow:
       - dependency-type: "all" # devDependenciesも含める
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,53 @@ updates:
       - "dependabot"
     rebase-strategy: auto
     target-branch: "dev"
+    groups:
+      # MUI関連パッケージをまとめる
+      mui-stack:
+        patterns:
+          - "@mui/*"
+          - "@emotion/*"
+      # React関連パッケージをまとめる
+      react-stack:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "react-redux"
+          - "react-resizable-panels"
+      # Redux関連パッケージをまとめる
+      redux-stack:
+        patterns:
+          - "@reduxjs/toolkit"
+          - "redux"
+      # TypeScript関連パッケージをまとめる
+      typescript-stack:
+        patterns:
+          - "typescript"
+          - "ts-loader"
+          - "ts-node"
+          - "@types/*"
+      # Webpack関連パッケージをまとめる
+      webpack-stack:
+        patterns:
+          - "webpack"
+          - "webpack-cli"
+          - "*-webpack-plugin"
+          - "*-loader"
+      # Electron関連パッケージをまとめる
+      electron-stack:
+        patterns:
+          - "electron"
+          - "electronmon"
+          - "@electron/*"
+          - "@types/electron"
+      # 開発ツール関連をまとめる
+      dev-tools:
+        patterns:
+          - "rimraf"
+          - "copyfiles"
+          - "cross-env"
+          - "npm-run-all"
+          - "wait-on"
+          - "@trivago/prettier-plugin-sort-imports"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the maximum number of open dependency update pull requests from 10 to 20.
  * Organized dependency updates into categorized groups for streamlined management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->