### PR TITLE
feat: remove all 'any' types and improve type safety

### DIFF
--- a/src/electron/ipcHandlers.ts
+++ b/src/electron/ipcHandlers.ts
@@ -2,7 +2,7 @@ import { app, dialog, ipcMain, safeStorage } from 'electron';
 import * as fs from 'fs';
 import path from 'path';
 
-import TreeNode from '../renderer/models/treeNode';
+import { TreeNodePlain } from '../renderer/models/treeNode';
 import {
   STORE_KEY_TREE_VIEW_EXPANDED_ITEMS,
   STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID
@@ -35,7 +35,7 @@ const getSampleJsonData = () => JSON.parse(readFile2String(SAMPLE_CREDENTIALS_PA
 
 const questionDialog = new QuestionDialog();
 
-const saveEncryptedData = (path: string, data: TreeNode[]) => {
+const saveEncryptedData = (path: string, data: TreeNodePlain[]) => {
   const encrypted = safeStorage.encryptString(JSON.stringify(data));
   fs.writeFileSync(path, new Uint8Array(encrypted));
 };
@@ -51,7 +51,7 @@ const generateExportFilePath = (extension: string) => {
   return path.join(app.getPath('desktop'), fileName);
 };
 
-const exportErrorlog = (err: any) => {
+const exportErrorlog = (err: Error) => {
   console.log('[Error Log]', err);
   dialog.showMessageBox({
     type: 'warning',
@@ -85,13 +85,13 @@ const handleReadNodes = async () => {
   }
 };
 
-const handleSaveNodes = async (event: Electron.IpcMainInvokeEvent, data: TreeNode[]) => {
+const handleSaveNodes = async (event: Electron.IpcMainInvokeEvent, data: TreeNodePlain[]) => {
   questionDialog.showMessageBox('現在の内容で保存してもよろしいですか？', () =>
     saveEncryptedData(CREDENTIALS_PATH, data)
   );
 };
 
-const handleExportNodes = async (event: Electron.IpcMainInvokeEvent, data: TreeNode[]) => {
+const handleExportNodes = async (event: Electron.IpcMainInvokeEvent, data: TreeNodePlain[]) => {
   questionDialog.showMessageBox(
     '機密情報を暗号化した状態で保存しますか？',
     () => {
@@ -135,8 +135,11 @@ const handleExportNodes = async (event: Electron.IpcMainInvokeEvent, data: TreeN
 
 const handleGetSetting = (key: string) => store.get(key);
 
-const handleUpdateSetting = (_: Electron.IpcMainInvokeEvent, key: string, value: any) =>
-  store.set(key, value);
+const handleUpdateSetting = (
+  _: Electron.IpcMainInvokeEvent,
+  key: string,
+  value: string | boolean
+) => store.set(key, value);
 
 const handleGetBackupSettings = () => {
   return {

--- a/src/renderer/components/Settings/Settings.tsx
+++ b/src/renderer/components/Settings/Settings.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { BackupSettings } from '../../../shared/types/BackupSettings';
 import { Box, Checkbox, FormControlLabel, TextField, Button } from '@mui/material';
 
-const { api } = window as any;
+const { api } = window;
 
 const Settings: React.FC = () => {
   const [backupEnabled, setBackupEnabled] = useState(false);

--- a/src/renderer/hooks/useEventListeners.ts
+++ b/src/renderer/hooks/useEventListeners.ts
@@ -12,20 +12,39 @@ const useEventListeners = () => {
   const addSubItemHandler = useAddNewSubItem();
   const removeSubtreeHandler = useRemoveSubtree();
   const exportItemHandler = useExportItems();
-  const importItems = useImportItems();
 
-  const useSetupEventListener = (eventName: string, handler: () => void) =>
-    useEffect(() => {
-      const eventHandler = () => handler();
-      (window as any).api[`on${eventName}`](eventHandler);
-      return () => (window as any).api[`off${eventName}`](eventHandler);
-    }, [handler]);
+  // Import items hook is called for its side effects (sets up onImportData listener)
+  useImportItems();
 
-  useSetupEventListener('SaveData', saveHandler);
-  useSetupEventListener('AddTopItem', addTopItemHandler);
-  useSetupEventListener('AddSubItem', addSubItemHandler);
-  useSetupEventListener('RemoveSubtree', removeSubtreeHandler);
-  useSetupEventListener('ExportData', exportItemHandler);
+  useEffect(() => {
+    const eventHandler = () => saveHandler();
+    window.api.onSaveData(eventHandler);
+    return () => window.api.offSaveData(eventHandler);
+  }, [saveHandler]);
+
+  useEffect(() => {
+    const eventHandler = () => addTopItemHandler();
+    window.api.onAddTopItem(eventHandler);
+    return () => window.api.offAddTopItem(eventHandler);
+  }, [addTopItemHandler]);
+
+  useEffect(() => {
+    const eventHandler = () => addSubItemHandler();
+    window.api.onAddSubItem(eventHandler);
+    return () => window.api.offAddSubItem(eventHandler);
+  }, [addSubItemHandler]);
+
+  useEffect(() => {
+    const eventHandler = () => removeSubtreeHandler();
+    window.api.onRemoveSubtree(eventHandler);
+    return () => window.api.offRemoveSubtree(eventHandler);
+  }, [removeSubtreeHandler]);
+
+  useEffect(() => {
+    const eventHandler = () => exportItemHandler();
+    window.api.onExportData(eventHandler);
+    return () => window.api.offExportData(eventHandler);
+  }, [exportItemHandler]);
 };
 
 export default useEventListeners;

--- a/src/renderer/hooks/useExportItems.ts
+++ b/src/renderer/hooks/useExportItems.ts
@@ -4,7 +4,7 @@ import { stagingItemData } from '../store/item-slice';
 
 const useExportItems = () => {
   const itemData = useSelector(stagingItemData);
-  return async () => await (window as any).api.exportNodes(itemData);
+  return async () => await window.api.exportNodes(itemData);
 };
 
 export default useExportItems;

--- a/src/renderer/hooks/useImportItems.ts
+++ b/src/renderer/hooks/useImportItems.ts
@@ -2,17 +2,17 @@ import { plainToInstance } from 'class-transformer';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
-import TreeNode from '../models/treeNode';
+import TreeNode, { TreeNodePlain } from '../models/treeNode';
 import { itemActions } from '../store/item-slice';
 
 const useImportItems = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    (window as any).api.onImportData((parsedObject: any) =>
+    window.api.onImportData((parsedObject: TreeNodePlain[]) =>
       dispatch(itemActions.updateStagingData(plainToInstance(TreeNode, parsedObject)))
     );
-  }, []);
+  }, [dispatch]);
 };
 
 export default useImportItems;

--- a/src/renderer/hooks/useSaveItems.ts
+++ b/src/renderer/hooks/useSaveItems.ts
@@ -13,7 +13,7 @@ const useSaveItems = () => {
 
   return async () => {
     if (hasDifference) {
-      const hasSaved = await (window as any).api.saveNodes(itemData);
+      const hasSaved = await window.api.saveNodes(itemData);
       if (hasSaved) {
         dispatch(itemActions.updateMainState());
       }

--- a/src/renderer/models/credential.ts
+++ b/src/renderer/models/credential.ts
@@ -12,4 +12,9 @@ class Credential {
   }
 }
 
+// Credentialクラスのプレーンオブジェクト型
+export type CredentialPlain = {
+  [K in keyof Credential]: Credential[K];
+};
+
 export default Credential;

--- a/src/renderer/models/treeNode.ts
+++ b/src/renderer/models/treeNode.ts
@@ -1,6 +1,13 @@
 import { uuidv7 } from 'uuidv7';
 
-import TreeNodeData from './treeNodeData';
+import TreeNodeData, { TreeNodeDataPlain } from './treeNodeData';
+
+// TreeNodeのプレーンオブジェクト型
+export interface TreeNodePlain {
+  id: string;
+  data: TreeNodeDataPlain;
+  children?: TreeNodePlain[];
+}
 
 class TreeNode {
   public readonly id: string = uuidv7();

--- a/src/renderer/models/treeNodeData.ts
+++ b/src/renderer/models/treeNodeData.ts
@@ -1,8 +1,14 @@
-import Credential from './credential';
+import Credential, { CredentialPlain } from './credential';
 
 interface TreeNodeData {
   title: string;
   credentials: Credential[];
 }
+
+// TreeNodeDataのプレーンオブジェクト型
+export type TreeNodeDataPlain = {
+  title: string;
+  credentials: CredentialPlain[];
+};
 
 export default TreeNodeData;

--- a/src/renderer/store/item-slice.ts
+++ b/src/renderer/store/item-slice.ts
@@ -5,14 +5,12 @@ import TreeNode from '../models/treeNode';
 
 import { plainToInstance } from 'class-transformer';
 
-const { api } = window as any;
-
 const getInitialNodes = async (): Promise<TreeNode[]> =>
-  plainToInstance(TreeNode, await api.readNodes());
+  plainToInstance(TreeNode, await window.api.readNodes());
 const getInitialExpandedItemIds = async (): Promise<string[]> =>
-  await api.getTreeViewExpandedItems();
+  await window.api.getTreeViewExpandedItems();
 const getInitialSelectedItemId = async (): Promise<string | undefined> =>
-  await api.getTreeViewSelectedItemId();
+  await window.api.getTreeViewSelectedItemId();
 
 const initialNodes = await getInitialNodes();
 const initialExpandedItemIds = await getInitialExpandedItemIds();
@@ -118,11 +116,11 @@ const itemSlice = createSlice({
         }
       }
       state.activeNode = foundNode;
-      api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
+      window.api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
     },
     updateActiveNode: (state, action: PayloadAction<TreeNode | null>) => {
       state.activeNode = action.payload;
-      api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
+      window.api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
     },
     updateItem: (state, action: PayloadAction<TreeNode>) => {
       const queue = new Queue<TreeNode>();
@@ -204,7 +202,7 @@ const itemSlice = createSlice({
         } else {
           state.activeNode = state.itemData.staging.length > 0 ? state.itemData.staging[0] : null;
         }
-        api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
+        window.api.saveTreeViewSelectedItemId(state.activeNode ? state.activeNode.id : null);
       }
     },
     updateMainState: state => {
@@ -215,7 +213,7 @@ const itemSlice = createSlice({
     },
     setExpandedItemIds: (state, action: PayloadAction<string[]>) => {
       state.expandedItemIds = action.payload;
-      api.saveTreeViewExpandedItems(state.expandedItemIds);
+      window.api.saveTreeViewExpandedItems(state.expandedItemIds);
     }
   }
 });

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -1,0 +1,9 @@
+import { ElectronAPI } from '../../shared/types/ElectronAPI';
+
+declare global {
+  interface Window {
+    api: ElectronAPI;
+  }
+}
+
+export {};

--- a/src/shared/types/ElectronAPI.ts
+++ b/src/shared/types/ElectronAPI.ts
@@ -1,0 +1,31 @@
+import { BackupSettings } from './BackupSettings';
+import { TreeNodePlain } from '../../renderer/models/treeNode';
+
+export interface ElectronAPI {
+  // Backup settings
+  getBackupSettings(): Promise<BackupSettings>;
+  updateSetting(key: keyof BackupSettings, value: string | boolean): void;
+  selectBackupPath(): Promise<string | null>;
+
+  // Tree view operations
+  readNodes(): Promise<TreeNodePlain[]>;
+  saveNodes(nodes: TreeNodePlain[]): Promise<boolean>;
+  exportNodes(nodes: TreeNodePlain[]): Promise<void>;
+  onImportData(callback: (data: TreeNodePlain[]) => void): void;
+  getTreeViewExpandedItems(): Promise<string[]>;
+  getTreeViewSelectedItemId(): Promise<string | undefined>;
+  saveTreeViewSelectedItemId(itemId: string | null): void;
+  saveTreeViewExpandedItems(expandedItemIds: string[]): void;
+
+  // Event listeners
+  onSaveData(callback: () => void): void;
+  offSaveData(callback: () => void): void;
+  onAddTopItem(callback: () => void): void;
+  offAddTopItem(callback: () => void): void;
+  onAddSubItem(callback: () => void): void;
+  offAddSubItem(callback: () => void): void;
+  onRemoveSubtree(callback: () => void): void;
+  offRemoveSubtree(callback: () => void): void;
+  onExportData(callback: () => void): void;
+  offExportData(callback: () => void): void;
+}


### PR DESCRIPTION
- Replace 'window as any' with proper ElectronAPI interface
- Add type definitions for ElectronAPI, TreeNodePlain, CredentialPlain
- Create global.d.ts for window object extension
- Update all hooks and components to use typed API calls
- Improve preload.ts with proper type definitions
- Add development environment dual save for credentials
- Organize type definitions near related models for better maintainability