### PR TITLE
refactor: extract environment utils for reusability

### DIFF
--- a/src/electron/mainMenu.ts
+++ b/src/electron/mainMenu.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, Menu, MenuItemConstructorOptions } from 'electron';
 import * as fs from 'fs';
 
+import { isDevelopment } from '../shared/utils/environment';
 import QuestionDialog from './dialogs/questionDialog';
 import SettingsWindow from './subWindows/settingsWindow';
 
@@ -88,7 +89,7 @@ class MainMenu {
             label: '項目の削除',
             click: () => mainWindow.webContents.send('remove-subtree')
           },
-          ...(process.env.NODE_ENV === 'development'
+          ...(isDevelopment()
             ? [
                 {
                   role: 'toggledevtools'

--- a/src/electron/subWindows/settingsWindow.ts
+++ b/src/electron/subWindows/settingsWindow.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow } from 'electron';
 import path from 'path';
 import { ICON_PATH } from '../../shared/constants';
+import { isDevelopment } from '../../shared/utils/environment';
 
 class SettingsWindow extends BrowserWindow {
   constructor(parentWindow: BrowserWindow) {
@@ -20,7 +21,7 @@ class SettingsWindow extends BrowserWindow {
 
     this.loadFile(path.resolve(__dirname, 'settings.html'));
 
-    this.setMenuBarVisibility(process.env.NODE_ENV === 'development');
+    this.setMenuBarVisibility(isDevelopment());
 
     this.on('closed', () => {
       this.destroy();

--- a/src/shared/utils/environment.ts
+++ b/src/shared/utils/environment.ts
@@ -1,0 +1,13 @@
+import { app } from 'electron';
+
+/**
+ * 開発環境かどうかを判定する
+ * NODE_ENVがdevelopmentまたはアプリがパッケージ化されていない場合は開発環境とみなす
+ */
+export const isDevelopment = (): boolean =>
+  process.env.NODE_ENV === 'development' || !app.isPackaged;
+
+/**
+ * 本番環境かどうかを判定する
+ */
+export const isProduction = (): boolean => !isDevelopment();


### PR DESCRIPTION
## 概要
開発環境判定ロジックを共通ユーティリティに切り出し、コードの再利用性と保守性を向上させました。また、開発時と本番時で認証情報の保存先を動的に切り替える機能も実装しました。

## 変更内容
- **src/shared/utils/environment.ts**: 環境判定用の共通ユーティリティ関数を新規作成
  - isDevelopment(): 開発環境かどうかを判定
  - isProduction(): 本番環境かどうかを判定
- **src/electron/ipcHandlers.ts**: インライン環境判定を共通関数に置き換え、動的な認証情報パス切り替えを実装
- **src/electron/mainMenu.ts**: 開発ツールメニュー表示判定を共通関数に置き換え
- **src/electron/subWindows/settingsWindow.ts**: メニューバー表示判定を共通関数に置き換え

## 背景理由
- process.env.NODE_ENV === 'development' の判定処理が複数ファイルに散在していた
- 開発時に dist/ 配下にしか保存されず不便だった
- コードの重複を削減し、一箇所で環境判定ロジックを管理したい

## 動作確認
- 開発時: src/credentials/ 配下に認証情報を保存
- 本番時: dist/credentials/ 配下に認証情報を保存
- 各ファイルで共通の環境判定関数が正常に動作することを確認