### PR TITLE
Improve DetailView tests

### DIFF
--- a/src/renderer/components/Layout/DetailView.tsx
+++ b/src/renderer/components/Layout/DetailView.tsx
@@ -122,7 +122,10 @@ const DetailView = () => {
       return (
         <div key={credential.id}>
           <Box display='flex' alignItems='center' sx={{ flexGrow: 1 }}>
-            <IconButton onClick={() => navigator.clipboard.writeText(credential.name)}>
+            <IconButton
+              onClick={() => navigator.clipboard.writeText(credential.name)}
+              aria-label='copy-name'
+            >
               <ContentCopyIcon />
             </IconButton>
             <FormControl sx={{ m: 1, width: '25ch' }} variant='outlined'>
@@ -134,7 +137,10 @@ const DetailView = () => {
                 onChange={updateNameHandler}
               />
             </FormControl>
-            <IconButton onClick={() => navigator.clipboard.writeText(credential.value)}>
+            <IconButton
+              onClick={() => navigator.clipboard.writeText(credential.value)}
+              aria-label='copy-value'
+            >
               <ContentCopyIcon />
             </IconButton>
             <FormControl sx={{ m: 1, width: '25ch' }} variant='outlined'>

--- a/src/renderer/components/Layout/DetailView.tsx
+++ b/src/renderer/components/Layout/DetailView.tsx
@@ -160,7 +160,11 @@ const DetailView = () => {
                 label='value'
               />
             </FormControl>
-            <IconButton color='error' onClick={() => removeCredentialHandler(credential.id)}>
+            <IconButton
+              color='error'
+              onClick={() => removeCredentialHandler(credential.id)}
+              aria-label='remove-credential'
+            >
               <IndeterminateCheckBoxIcon />
             </IconButton>
           </Box>
@@ -187,7 +191,7 @@ const DetailView = () => {
         </Typography>
       </Box>
       <Box display='flex' alignItems='left' justifyContent='left' sx={{ flexGrow: 1, ml: 40 }}>
-        <IconButton color='primary' onClick={addNewCredentialHandler}>
+        <IconButton color='primary' onClick={addNewCredentialHandler} aria-label='add-credential'>
           <AddBoxIcon />
         </IconButton>
       </Box>

--- a/src/renderer/components/Layout/__tests__/DetailView.test.tsx
+++ b/src/renderer/components/Layout/__tests__/DetailView.test.tsx
@@ -1,0 +1,361 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DetailView from '../DetailView';
+import TreeNode from '../../../models/treeNode';
+import Credential from '../../../models/credential';
+import { uuidv7 } from 'uuidv7';
+import {
+  createTestNode,
+  renderWithStore,
+  createStoreWithItems,
+  getActiveNode
+} from './utils/helpers';
+
+describe('DetailView', () => {
+  // ストアの状態からstagingアイテムを取得するヘルパー関数
+  const getStagingItems = (store: ReturnType<typeof createStoreWithItems>) => {
+    return store.getState().item.itemData.staging;
+  };
+
+  const renderDetailView = (
+    stagingItems: TreeNode[] = [],
+    activeNode: TreeNode | null = null,
+    expandedItemIds: string[] = []
+  ) => {
+    return renderWithStore(DetailView, stagingItems, [], activeNode, expandedItemIds);
+  };
+
+  // テスト用のクレデンシャルを作成するヘルパー関数
+  const createTestCredential = (overrides: Partial<Credential> = {}) => {
+    return new Credential({
+      name: uuidv7(),
+      value: uuidv7(),
+      showValue: false,
+      ...overrides
+    });
+  };
+
+  // 複数のテスト用クレデンシャルを作成するヘルパー関数
+  const createTestCredentials = (count: number) =>
+    Array.from({ length: count }, () => createTestCredential());
+
+  describe('rendering', () => {
+    it('renders empty detail view when no active node', () => {
+      renderDetailView();
+
+      // タイトルフィールドが空で表示されることを確認
+      const titleField = screen.getByLabelText('Title');
+      expect(titleField).toBeInTheDocument();
+      expect(titleField).toHaveValue('');
+
+      // 新しいクレデンシャル追加ボタンが表示されることを確認
+      const addButton = screen.getByLabelText('add-credential');
+      expect(addButton).toBeInTheDocument();
+    });
+
+    it('renders detail view with active node title', () => {
+      const testNode = createTestNode({ title: 'Test Item', credentials: [] });
+      renderDetailView([testNode], testNode);
+
+      // タイトルフィールドにアクティブノードのタイトルが表示されることを確認
+      const titleField = screen.getByLabelText('Title');
+      expect(titleField).toHaveValue('Test Item');
+    });
+
+    it('renders detail view with credentials', () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      renderDetailView([testNode], testNode);
+
+      // クレデンシャルのフィールドが表示されることを確認
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      // Valueフィールドは OutlinedInput なので、プレースホルダーテキストで確認
+      expect(screen.getByText('Value')).toBeInTheDocument();
+
+      // クレデンシャルの値が表示されることを確認
+      expect(screen.getByDisplayValue(credential.name)).toBeInTheDocument();
+      expect(screen.getByDisplayValue(credential.value)).toBeInTheDocument();
+    });
+
+    it('renders many credentials efficiently', () => {
+      const credentials = createTestCredentials(5);
+      const testNode = createTestNode({
+        title: 'Test Item with Many Credentials',
+        credentials
+      });
+      renderDetailView([testNode], testNode);
+
+      // 5つのクレデンシャルがすべて表示されることを確認
+      credentials.forEach(credential => {
+        expect(screen.getByDisplayValue(`${credential.name}`)).toBeInTheDocument();
+        expect(screen.getByDisplayValue(`${credential.value}`)).toBeInTheDocument();
+      });
+
+      // 削除ボタンも5つ表示されることを確認
+      const removeButtons = screen.getAllByLabelText('remove-credential');
+      expect(removeButtons).toHaveLength(5);
+    });
+
+    it('renders password field as hidden by default', () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      renderDetailView([testNode], testNode);
+
+      // パスワードフィールドがhiddenタイプで表示されることを確認
+      const passwordField = screen.getByDisplayValue(credential.value);
+      expect(passwordField).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('title interactions', () => {
+    let user: ReturnType<typeof userEvent.setup>;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('updates title when title field is changed', async () => {
+      const testNode = createTestNode({ title: 'Original Title', credentials: [] });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const titleField = screen.getByLabelText('Title');
+      await user.clear(titleField);
+      await user.type(titleField, 'Updated Title');
+
+      // ストアの状態が更新されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.title).toBe('Updated Title');
+      });
+    });
+
+    it('updates staging items when title is changed', async () => {
+      const testNode = createTestNode({ title: 'Original Title', credentials: [] });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const titleField = screen.getByLabelText('Title');
+      await user.clear(titleField);
+      await user.type(titleField, 'Updated Title');
+
+      // stagingアイテムも更新されることを確認
+      await waitFor(() => {
+        const stagingItems = getStagingItems(store);
+        const updatedItem = stagingItems.find(item => item.id === testNode.id);
+        expect(updatedItem?.data.title).toBe('Updated Title');
+      });
+    });
+  });
+
+  describe('credential interactions', () => {
+    let user: ReturnType<typeof userEvent.setup>;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('updates credential name when name field is changed', async () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const nameField = screen.getByDisplayValue(credential.name);
+      await user.clear(nameField);
+      await user.type(nameField, 'updated-username');
+
+      // ストアの状態が更新されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials[0].name).toBe('updated-username');
+      });
+    });
+
+    it('updates credential value when password field is changed', async () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const passwordField = screen.getByDisplayValue(credential.value);
+      await user.clear(passwordField);
+      await user.type(passwordField, 'updated-password');
+
+      // ストアの状態が更新されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials[0].value).toBe('updated-password');
+      });
+    });
+
+    it('toggles password visibility when visibility button is clicked', async () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const visibilityButton = screen.getByLabelText('toggle password visibility');
+      const passwordField = screen.getByDisplayValue(credential.value);
+
+      // 初期状態ではパスワードが隠されていることを確認
+      expect(passwordField).toHaveAttribute('type', 'password');
+
+      // 表示ボタンをクリック
+      await user.click(visibilityButton);
+
+      // パスワードが表示されることを確認
+      await waitFor(() => {
+        expect(passwordField).toHaveAttribute('type', 'text');
+      });
+
+      // ストアの状態も更新されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials[0].showValue).toBe(true);
+      });
+    });
+
+    it('adds new credential when add button is clicked', async () => {
+      const testNode = createTestNode({ title: 'Test Item', credentials: [] });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const addButton = screen.getByLabelText('add-credential');
+      await user.click(addButton);
+
+      // 新しいクレデンシャルが追加されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials.length).toBe(1);
+      });
+
+      // 新しいフィールドが表示されることを確認
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Value')).toBeInTheDocument();
+    });
+
+    it('removes credential when remove button is clicked', async () => {
+      const credential = createTestCredential();
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const removeButton = screen.getByLabelText('remove-credential');
+      await user.click(removeButton);
+
+      // クレデンシャルが削除されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials.length).toBe(0);
+      });
+
+      // フィールドが非表示になることを確認
+      await waitFor(() => {
+        expect(screen.queryByDisplayValue(credential.name)).not.toBeInTheDocument();
+        expect(screen.queryByDisplayValue(credential.value)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('clipboard interactions', () => {
+    let user: ReturnType<typeof userEvent.setup>;
+    let mockWriteText: jest.SpyInstance;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+      // navigator.clipboard.writeTextをモック
+      mockWriteText = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      mockWriteText.mockRestore();
+    });
+
+    it('copies credential name to clipboard when name copy button is clicked', async () => {
+      const credential = createTestCredential({ name: 'copy-test-name' });
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      renderDetailView([testNode], testNode);
+
+      // 名前フィールドの隣にあるコピーボタンをクリック
+      const copyButtons = screen.getAllByRole('button');
+      const nameCopyButton = copyButtons[0]; // 最初のコピーボタンは名前用
+
+      await user.click(nameCopyButton);
+
+      // クリップボードにコピーされることを確認
+      expect(mockWriteText).toHaveBeenCalledWith('copy-test-name');
+    });
+
+    it('copies credential value to clipboard when value copy button is clicked', async () => {
+      const credential = createTestCredential({ value: 'copy-test-value' });
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials: [credential]
+      });
+      renderDetailView([testNode], testNode);
+
+      // 値フィールドの隣にあるコピーボタンをクリック
+      const copyButtons = screen.getAllByRole('button');
+      const valueCopyButton = copyButtons[1]; // 2番目のコピーボタンは値用
+
+      await user.click(valueCopyButton);
+
+      // クリップボードにコピーされることを確認
+      expect(mockWriteText).toHaveBeenCalledWith('copy-test-value');
+    });
+  });
+
+  describe('state synchronization', () => {
+    it('renders correctly with different active nodes', () => {
+      const node1 = createTestNode({ title: 'First Node', credentials: [] });
+
+      // ノードでレンダリング
+      renderDetailView([node1], node1);
+      expect(screen.getByDisplayValue('First Node')).toBeInTheDocument();
+
+      // コンポーネントが正しくレンダリングされることを確認
+      expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    });
+
+    it('maintains credential state consistency', async () => {
+      const credentials = [
+        createTestCredential({ name: 'cred1', value: 'val1' }),
+        createTestCredential({ name: 'cred2', value: 'val2' })
+      ];
+      const testNode = createTestNode({
+        title: 'Test Item',
+        credentials
+      });
+      const { store } = renderDetailView([testNode], testNode);
+
+      const user = userEvent.setup();
+
+      // 最初のクレデンシャルの名前を更新
+      const firstNameField = screen.getByDisplayValue('cred1');
+      await user.clear(firstNameField);
+      await user.type(firstNameField, 'updated-cred1');
+
+      // ストアの状態が正しく更新されることを確認
+      await waitFor(() => {
+        const activeNode = getActiveNode(store);
+        expect(activeNode?.data.credentials[0].name).toBe('updated-cred1');
+        expect(activeNode?.data.credentials[1].name).toBe('cred2'); // 他のクレデンシャルは変更されない
+      });
+    });
+  });
+});

--- a/src/renderer/components/Layout/__tests__/DetailView.test.tsx
+++ b/src/renderer/components/Layout/__tests__/DetailView.test.tsx
@@ -291,9 +291,8 @@ describe('DetailView', () => {
       });
       renderDetailView([testNode], testNode);
 
-      // 名前フィールドの隣にあるコピーボタンをクリック
-      const copyButtons = screen.getAllByRole('button');
-      const nameCopyButton = copyButtons[0]; // 最初のコピーボタンは名前用
+      // aria-labelを使って名前用のコピーボタンを特定
+      const nameCopyButton = screen.getByLabelText('copy-name');
 
       await user.click(nameCopyButton);
 
@@ -309,9 +308,8 @@ describe('DetailView', () => {
       });
       renderDetailView([testNode], testNode);
 
-      // 値フィールドの隣にあるコピーボタンをクリック
-      const copyButtons = screen.getAllByRole('button');
-      const valueCopyButton = copyButtons[1]; // 2番目のコピーボタンは値用
+      // aria-labelを使って値用のコピーボタンを特定
+      const valueCopyButton = screen.getByLabelText('copy-value');
 
       await user.click(valueCopyButton);
 

--- a/src/renderer/components/Layout/__tests__/ItemTreeView.test.tsx
+++ b/src/renderer/components/Layout/__tests__/ItemTreeView.test.tsx
@@ -6,15 +6,11 @@ import {
   createTestNode,
   renderWithStore,
   createParentChildNodes,
-  createStoreWithItems
+  createStoreWithItems,
+  getActiveNode
 } from './utils/helpers';
 
 describe('ItemTreeView', () => {
-  // ストアの状態からアクティブノードIDを取得するヘルパー関数
-  const getActiveNodeId = (store: ReturnType<typeof createStoreWithItems>) => {
-    return store.getState().item.activeNode?.id || null;
-  };
-
   // ストアの状態から展開されたアイテムIDsを取得するヘルパー関数
   const getExpandedItemIds = (store: ReturnType<typeof createStoreWithItems>) => {
     return store.getState().item.expandedItemIds;
@@ -91,21 +87,21 @@ describe('ItemTreeView', () => {
       const { store } = renderItemTreeView([testNode1, testNode2]);
 
       // 初期状態ではアクティブノードがないことを確認
-      expect(getActiveNodeId(store)).toBeNull();
+      expect(getActiveNode(store)?.id || null).toBeNull();
 
       // 最初のアイテムをクリック
       const firstItem = screen.getByText('first-item');
       await user.click(firstItem);
 
       // アクティブノードが変更されることを確認
-      expect(getActiveNodeId(store)).toBe(testNode1.id);
+      expect(getActiveNode(store)?.id).toBe(testNode1.id);
 
       // 2番目のアイテムをクリック
       const secondItem = screen.getByText('second-item');
       await user.click(secondItem);
 
       // アクティブノードが2番目のアイテムに変更されることを確認
-      expect(getActiveNodeId(store)).toBe(testNode2.id);
+      expect(getActiveNode(store)?.id).toBe(testNode2.id);
     });
 
     it('changes active node when nested item is clicked', async () => {
@@ -113,21 +109,21 @@ describe('ItemTreeView', () => {
       const { store } = renderItemTreeView([parentNode], null, [parentNode.id]);
 
       // 初期状態ではアクティブノードがないことを確認
-      expect(getActiveNodeId(store)).toBeNull();
+      expect(getActiveNode(store)?.id || null).toBeNull();
 
       // 子アイテムをクリック
       const childItem = screen.getByText('child-item');
       await user.click(childItem);
 
       // アクティブノードが子ノードに変更されることを確認
-      expect(getActiveNodeId(store)).toBe(childNode.id);
+      expect(getActiveNode(store)?.id).toBe(childNode.id);
 
       // 親アイテムをクリック
       const parentItem = screen.getByText('parent-item');
       await user.click(parentItem);
 
       // アクティブノードが親ノードに変更されることを確認
-      expect(getActiveNodeId(store)).toBe(parentNode.id);
+      expect(getActiveNode(store)?.id).toBe(parentNode.id);
     });
 
     it('maintains active node selection when same item is clicked multiple times', async () => {
@@ -138,11 +134,11 @@ describe('ItemTreeView', () => {
 
       // 最初のクリック
       await user.click(testItem);
-      expect(getActiveNodeId(store)).toBe(testNode.id);
+      expect(getActiveNode(store)?.id).toBe(testNode.id);
 
       // 同じアイテムを再度クリック
       await user.click(testItem);
-      expect(getActiveNodeId(store)).toBe(testNode.id);
+      expect(getActiveNode(store)?.id).toBe(testNode.id);
     });
 
     it('updates expanded state when item is expanded by user click', async () => {

--- a/src/renderer/components/Layout/__tests__/utils/helpers.ts
+++ b/src/renderer/components/Layout/__tests__/utils/helpers.ts
@@ -68,3 +68,7 @@ export const createParentChildNodes = (parentTitle = 'parent-item', childTitle =
 
   return { parentNode, childNode };
 };
+
+// ストアの状態からアクティブノードを取得するヘルパー関数
+export const getActiveNode = (store: ReturnType<typeof createStoreWithItems>) =>
+  store.getState().item.activeNode;


### PR DESCRIPTION
DetailViewコンポーネントのテストを改善しました

- テストヘルパー関数を追加
- より包括的なテストケースを実装
- テストの可読性と保守性を向上

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added ARIA labels to copy, add, and remove credential buttons to improve screen reader support.

* **Tests**
  * Added comprehensive Detail View tests covering rendering, title/credential edits, add/remove, password visibility, and clipboard copy.
  * Updated Item Tree tests to use a shared active-node helper and introduced a reusable test helper for active node retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->