### PR TITLE
chore(dependabot): Update groups and schedule interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,7 @@ updates:
           - "webpack-cli"
           - "*-webpack-plugin"
           - "*-loader"
+          - "mini-css-extract-plugin"
       # Electron関連パッケージをまとめる
       electron-stack:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,8 @@ updates:
           - "ts-jest"
           - "@testing-library/*"
           - "@types/jest"
+          - "identity-obj-proxy"
+          - "jest-transform-stub"
       # Linter・Formatter関連パッケージをまとめる
       lint-stack:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/" # ルートに package.json がある場合
     schedule:
-      interval: "weekly" # or "daily" にすれば毎日更新
+      interval: "daily" # 3日に1回の指定は仕様上不可のため、最も近い「毎日」に設定
     open-pull-requests-limit: 20
     allow:
       - dependency-type: "all" # devDependenciesも含める
@@ -36,11 +36,29 @@ updates:
         patterns:
           - "@reduxjs/toolkit"
           - "redux"
+      # テスト関連パッケージをまとめる
+      test-stack:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "ts-jest"
+          - "@testing-library/*"
+          - "@types/jest"
+      # Linter・Formatter関連パッケージをまとめる
+      lint-stack:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "@trivago/prettier-plugin-sort-imports"
+          - "lint-staged"
+          - "husky"
       # TypeScript関連パッケージをまとめる
       typescript-stack:
         patterns:
           - "typescript"
-          - "ts-loader"
           - "ts-node"
           - "@types/*"
       # Webpack関連パッケージをまとめる
@@ -55,8 +73,8 @@ updates:
         patterns:
           - "electron"
           - "electronmon"
+          - "electron-*"
           - "@electron/*"
-          - "@types/electron"
       # 開発ツール関連をまとめる
       dev-tools:
         patterns:
@@ -65,4 +83,3 @@ updates:
           - "cross-env"
           - "npm-run-all"
           - "wait-on"
-          - "@trivago/prettier-plugin-sort-imports"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,6 @@ updates:
           - "@testing-library/*"
           - "@types/jest"
           - "identity-obj-proxy"
-          - "jest-transform-stub"
       # Linter・Formatter関連パッケージをまとめる
       lint-stack:
         patterns:


### PR DESCRIPTION
## Summary
Updated Dependabot configuration to accurately reflect the current project dependencies and optimized its update schedule.

## Background
The previous Dependabot group settings did not cover all testing and linting packages correctly. Additionally, the schedule needed to be as close to once every 3 days as possible, which was adjusted to `daily` due to Dependabot's built-in limitations.

## Changes
- (Config) Added `test-stack` group to bundle jest and testing library packages.
- (Config) Added `lint-stack` group to bundle eslint, prettier, husky, and related tools.
- (Config) Updated `electron-stack` to include related packages such as electron-builder and electron-store.
- (Config) Changed `schedule.interval` to `daily`.

## Implementation Notes
Due to Dependabot natively only supporting `daily`, `weekly`, or `monthly` interval options, `daily` was selected as the closest available option to the requested 3-day interval.

## Impact & Risks
No changes to application code. Pull requests generated by Dependabot will now be categorized more clearly, facilitating easier review and merging. No specific risks involved.

## Related (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to improve update frequency and organization of dependency groupings for testing, linting, and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->