### PR TITLE
fix: change dev config.json save location to separate from prod

### DIFF
--- a/src/electron/store.ts
+++ b/src/electron/store.ts
@@ -1,5 +1,13 @@
+import { app } from 'electron';
 import Store from 'electron-store';
+import path from 'path';
+import { isDevelopment } from './utils/environment';
 
-const store = new Store();
+const store = new Store({
+  // 開発時のみ '-dev'をつけたディレクトリに config.json を保存する
+  cwd: isDevelopment()
+    ? path.join(app.getPath('appData'), `${app.getName()}-dev`)
+    : app.getPath('userData')
+});
 
 export default store;

--- a/src/electron/store.ts
+++ b/src/electron/store.ts
@@ -1,13 +1,10 @@
 import { app } from 'electron';
 import Store from 'electron-store';
-import path from 'path';
 import { isDevelopment } from './utils/environment';
 
 const store = new Store({
   // 開発時のみ '-dev'をつけたディレクトリに config.json を保存する
-  cwd: isDevelopment()
-    ? path.join(app.getPath('appData'), `${app.getName()}-dev`)
-    : app.getPath('userData')
+  cwd: isDevelopment() ? `${app.getPath('userData')}-dev` : app.getPath('userData')
 });
 
 export default store;


### PR DESCRIPTION
## Summary
Isolated the electron-store configuration path in development to prevent it from overwriting the production configuration.

## Background
When running in development mode, electron-store defaults to the same userData directory as the production app, leading to configuration conflicts and overwriting of real data.

## Changes
- (Code) Updated src/electron/store.ts to use a separate \\-dev\ directory under appData when in development mode.

## Implementation Notes
Used app.getPath('appData') combined with the app name and a -dev suffix to create a distinct directory for development settings, ensuring isolation from the production environment.

## Impact & Risks
No impact on production builds. In development, configuration will now be stored in a new directory, which is a safe, non-breaking change.

## Related (optional)
- Issue: #...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the application's data storage architecture to support environment-specific directories and improve data management. The application now intelligently routes stored data to development-specific directories when in development mode and to standard application data directories in production, improving overall data isolation and ensuring cleaner separation between development and production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatsudaYoshio/password-manager/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->