### PR TITLE
feat: extract AppLoadingSpinner to a separate component

### DIFF
--- a/src/renderer/components/UI/AppLoadingSpinner.tsx
+++ b/src/renderer/components/UI/AppLoadingSpinner.tsx
@@ -1,8 +1,7 @@
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import React from 'react';
 
-export const AppLoadingSpinner: React.FC = () => {
+export const AppLoadingSpinner = () => {
   return (
     <Box
       sx={{

--- a/src/renderer/components/UI/AppLoadingSpinner.tsx
+++ b/src/renderer/components/UI/AppLoadingSpinner.tsx
@@ -1,0 +1,18 @@
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import React from 'react';
+
+export const AppLoadingSpinner: React.FC = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh'
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  );
+};

--- a/src/renderer/components/UI/AppLoadingSpinner.tsx
+++ b/src/renderer/components/UI/AppLoadingSpinner.tsx
@@ -12,7 +12,7 @@ export const AppLoadingSpinner: React.FC = () => {
         height: '100vh'
       }}
     >
-      <CircularProgress />
+      <CircularProgress aria-label='loading' />
     </Box>
   );
 };

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,10 +1,11 @@
+import 'normalize.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import 'normalize.css';
 
-import store, { initializeProductionStore } from './store/index';
 import { App } from './App';
+import { AppLoadingSpinner } from './components/UI/AppLoadingSpinner';
+import store, { initializeProductionStore } from './store/index';
 
 // アプリケーション初期化コンポーネント
 const AppWithInitialization = () => {
@@ -27,7 +28,7 @@ const AppWithInitialization = () => {
   }, []);
 
   if (!isInitialized) {
-    return <div>Loading...</div>;
+    return <AppLoadingSpinner />;
   }
 
   return (


### PR DESCRIPTION
AppWithInitialization 内で直接定義されていたローディングスピナーを、別コンポーネント AppLoadingSpinner として UI ディレクトリに切り出しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading spinner component that displays during app initialization, replacing the previous plain text loading indicator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatsudaYoshio/password-manager/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->