### PR TITLE
ci: use actions parallel steps in workflows

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,17 +20,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install depcheck
-        run: npm install -g depcheck
+      - parallel:
+          - name: Check for unused dependencies (ignore devDependencies)
+            shell: bash
+            run: |
+              npm install -g depcheck
+              IGNORES=$(node -p "Object.keys(require('./package.json').devDependencies).join(',')")
+              depcheck --ignores="$IGNORES,electron,webpack,webpack-cli,@eslint/js" || (echo "Unused dependencies found" && exit 1)
 
-      - name: Check for unused dependencies (ignore devDependencies)
-        shell: bash
-        run: |
-          IGNORES=$(node -p "Object.keys(require('./package.json').devDependencies).join(',')")
-          depcheck --ignores="$IGNORES,electron,webpack,webpack-cli,@eslint/js" || (echo "Unused dependencies found" && exit 1)
-
-      - name: Run tests
-        run: npm run test:ci
+          - name: Run tests
+            run: npm run test:ci
 
       - name: Run release (build & package)
         run: npm run release

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run ESLint
-        run: npm run lint
+      - parallel:
+          - name: Run ESLint
+            run: npm run lint
 
-      - name: Check Prettier formatting
-        run: npx prettier --check "src/**/*.{ts,tsx,js,json,css,md}"
+          - name: Check Prettier formatting
+            run: npx prettier --check "src/**/*.{ts,tsx,js,json,css,md}"


### PR DESCRIPTION
GitHub Actions の新しい parallel キーワードを使用し、互いに依存関係のないステップを並列実行するようにワークフローを更新しました。

### 変更内容
1. **lint-and-format.yml**
   - ESLint と Prettier formatting check を parallel ブロックに統合して並列実行化。
2. **build-and-release.yml**
   - depcheck とテスト（
pm run test:ci）を parallel ブロックに統合して並列実行化。
   - depcheck のグローバルインストール手順も parallel 内の同一タスクにまとめました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and release workflow efficiency by running dependency checks and tests in parallel.
  * Improved linting workflow efficiency by running ESLint and formatting checks concurrently.
  * Release packaging and artifact uploads remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->