### PR TITLE
refactor: Extract LeftPanel component and add size persistence

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,11 @@ const commonGlobals = {
   process: true,
   console: true,
   BufferEncoding: true,
-  Electron: true
+  Electron: true,
+  setTimeout: true,
+  clearTimeout: true,
+  setInterval: true,
+  clearInterval: true
 };
 
 const commonPlugins = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jest-fixed-jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/release/'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
@@ -31,5 +32,5 @@ module.exports = {
     ]
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/__tests__/utils/']
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/__tests__/utils/', '/release/']
 };

--- a/src/electron/ipcHandlers.ts
+++ b/src/electron/ipcHandlers.ts
@@ -4,14 +4,15 @@ import path from 'path';
 
 import { TreeNodePlain } from '../renderer/models/treeNode';
 import {
+  STORE_KEY_LEFT_PANEL_SIZE,
   STORE_KEY_TREE_VIEW_EXPANDED_ITEMS,
   STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID
 } from '../shared/constants';
 import { BackupSettings } from '../shared/types/BackupSettings';
-import { isDevelopment } from './utils/environment';
-import { getBackupSettings } from './utils/backupSettings';
 import QuestionDialog from './dialogs/questionDialog';
 import store from './store';
+import { getBackupSettings } from './utils/backupSettings';
+import { isDevelopment } from './utils/environment';
 
 // 開発時はsrc/credentials/、本番時はユーザーデータディレクトリを使用
 const getCredentialsFilePath = (filename: string) => {
@@ -66,6 +67,8 @@ const setupIpcHandlers = () => {
   ipcMain.handle('get-tree-view-expanded-items', handleGetTreeViewExpandedItems);
   ipcMain.handle('save-tree-view-selected-item-id', handleSaveTreeViewSelectedItemId);
   ipcMain.handle('get-tree-view-selected-item-id', handleGetTreeViewSelectedItemId);
+  ipcMain.handle('save-left-panel-size', handleSaveLeftPanelSize);
+  ipcMain.handle('get-left-panel-size', handleGetLeftPanelSize);
 };
 
 const readFile2String = (path: fs.PathOrFileDescriptor, encoding: BufferEncoding = 'utf-8') =>
@@ -247,6 +250,14 @@ const handleSaveTreeViewSelectedItemId = (
 const handleGetTreeViewSelectedItemId = (): string | undefined => {
   // store.get は値がない場合 undefined を返すので、そのまま返す
   return store.get(STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID) as string | undefined;
+};
+
+const handleSaveLeftPanelSize = (_: Electron.IpcMainInvokeEvent, size: number) => {
+  store.set(STORE_KEY_LEFT_PANEL_SIZE, size);
+};
+
+const handleGetLeftPanelSize = (): number | undefined => {
+  return store.get(STORE_KEY_LEFT_PANEL_SIZE) as number | undefined;
 };
 
 export default setupIpcHandlers;

--- a/src/electron/ipcHandlers.ts
+++ b/src/electron/ipcHandlers.ts
@@ -8,6 +8,7 @@ import {
   STORE_KEY_TREE_VIEW_EXPANDED_ITEMS,
   STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID
 } from '../shared/constants';
+import { LeftPanelSize } from '../shared/domain/LeftPanelSize';
 import { BackupSettings } from '../shared/types/BackupSettings';
 import QuestionDialog from './dialogs/questionDialog';
 import store from './store';
@@ -252,12 +253,14 @@ const handleGetTreeViewSelectedItemId = (): string | undefined => {
   return store.get(STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID) as string | undefined;
 };
 
-const handleSaveLeftPanelSize = (_: Electron.IpcMainInvokeEvent, size: number) => {
-  store.set(STORE_KEY_LEFT_PANEL_SIZE, size);
+const handleSaveLeftPanelSize = (_: Electron.IpcMainInvokeEvent, size: unknown) => {
+  const leftPanelSize = LeftPanelSize.create(size);
+  store.set(STORE_KEY_LEFT_PANEL_SIZE, leftPanelSize.toPrimitive());
 };
 
-const handleGetLeftPanelSize = (): number | undefined => {
-  return store.get(STORE_KEY_LEFT_PANEL_SIZE) as number | undefined;
+const handleGetLeftPanelSize = (): number => {
+  const raw = store.get(STORE_KEY_LEFT_PANEL_SIZE);
+  return LeftPanelSize.create(raw).toPrimitive();
 };
 
 export default setupIpcHandlers;

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -61,7 +61,9 @@ const api: ElectronAPI = {
   getTreeViewExpandedItems: () => ipcRenderer.invoke('get-tree-view-expanded-items'),
   saveTreeViewSelectedItemId: (selectedItemId: string | null) =>
     ipcRenderer.invoke('save-tree-view-selected-item-id', selectedItemId),
-  getTreeViewSelectedItemId: () => ipcRenderer.invoke('get-tree-view-selected-item-id')
+  getTreeViewSelectedItemId: () => ipcRenderer.invoke('get-tree-view-selected-item-id'),
+  saveLeftPanelSize: (size: number) => ipcRenderer.invoke('save-left-panel-size', size),
+  getLeftPanelSize: () => ipcRenderer.invoke('get-left-panel-size')
 };
 
 contextBridge.exposeInMainWorld('api', api);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { Group, Panel, Separator } from 'react-resizable-panels';
 import './App.css';
 import DetailView from './components/Layout/DetailView';
 import Header from './components/Layout/Header';
+import LeftPanel from './components/Layout/LeftPanel';
 import ItemTreeView from './components/Layout/ItemTreeView';
 import useEventListeners from './hooks/useEventListeners';
 
@@ -15,17 +16,9 @@ export const App = () => {
       <Header />
       <div style={{ flexGrow: 1, minHeight: 0 }}>
         <Group orientation='horizontal'>
-          <Panel
-            defaultSize='20%'
-            minSize='10%'
-            maxSize='30%'
-            style={{
-              overflowY: 'auto',
-              overflowX: 'hidden'
-            }}
-          >
+          <LeftPanel>
             <ItemTreeView />
-          </Panel>
+          </LeftPanel>
           <Separator style={{ width: '1px', backgroundColor: grey[300] }} />
           <Panel style={{ overflow: 'auto' }}>
             <DetailView />

--- a/src/renderer/components/Layout/LeftPanel.tsx
+++ b/src/renderer/components/Layout/LeftPanel.tsx
@@ -1,0 +1,54 @@
+import { ComponentProps, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { Panel } from 'react-resizable-panels';
+
+const DEFAULT_SIZE = 20;
+
+const LeftPanel = ({ children }: { children: ReactNode }) => {
+  const [initialSize, setInitialSize] = useState<number | null>(null);
+  const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const fetchSize = async () => {
+      const size = await window.api.getLeftPanelSize();
+      setInitialSize(size ?? DEFAULT_SIZE);
+    };
+    fetchSize();
+
+    return () => {
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleResize = useCallback<NonNullable<ComponentProps<typeof Panel>['onResize']>>(size => {
+    if (resizeTimeoutRef.current) {
+      clearTimeout(resizeTimeoutRef.current);
+    }
+
+    resizeTimeoutRef.current = setTimeout(() => {
+      window.api.saveLeftPanelSize(size.asPercentage).catch(console.error);
+    }, 500);
+  }, []);
+
+  if (initialSize === null) {
+    return null;
+  }
+
+  return (
+    <Panel
+      defaultSize={`${initialSize}%`}
+      minSize='10%'
+      maxSize='30%'
+      onResize={handleResize}
+      style={{
+        overflowY: 'auto',
+        overflowX: 'hidden'
+      }}
+    >
+      {children}
+    </Panel>
+  );
+};
+
+export default LeftPanel;

--- a/src/renderer/components/Layout/LeftPanel.tsx
+++ b/src/renderer/components/Layout/LeftPanel.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Panel } from 'react-resizable-panels';
 
-const DEFAULT_SIZE = 20;
+import { LeftPanelSize } from '../../../shared/domain/LeftPanelSize';
 
 const LeftPanel = ({ children }: { children: ReactNode }) => {
   const [initialSize, setInitialSize] = useState<number | null>(null);
@@ -10,7 +10,7 @@ const LeftPanel = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     const fetchSize = async () => {
       const size = await window.api.getLeftPanelSize();
-      setInitialSize(size ?? DEFAULT_SIZE);
+      setInitialSize(size ?? LeftPanelSize.DEFAULT);
     };
     fetchSize();
 
@@ -38,8 +38,8 @@ const LeftPanel = ({ children }: { children: ReactNode }) => {
   return (
     <Panel
       defaultSize={`${initialSize}%`}
-      minSize='10%'
-      maxSize='30%'
+      minSize={`${LeftPanelSize.MIN}%`}
+      maxSize={`${LeftPanelSize.MAX}%`}
       onResize={handleResize}
       style={{
         overflowY: 'auto',

--- a/src/renderer/components/Layout/__tests__/LeftPanel.test.tsx
+++ b/src/renderer/components/Layout/__tests__/LeftPanel.test.tsx
@@ -4,26 +4,21 @@
  * パネルのリサイズ、サイズの保存/読み込み機能を検証する
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeftPanel from '../LeftPanel';
+
+interface PanelMockProps {
+  children: React.ReactNode;
+  onResize?: (size: { asPercentage: number }) => void;
+  defaultSize?: string;
+  minSize?: string;
+  maxSize?: string;
+  style?: React.CSSProperties;
+}
 
 // react-resizable-panelsのモック
 jest.mock('react-resizable-panels', () => ({
-  Panel: ({
-    children,
-    onResize,
-    defaultSize,
-    minSize,
-    maxSize,
-    style
-  }: {
-    children: React.ReactNode;
-    onResize?: () => void;
-    defaultSize?: string;
-    minSize?: string;
-    maxSize?: string;
-    style?: React.CSSProperties;
-  }) => (
+  Panel: ({ children, onResize, defaultSize, minSize, maxSize, style }: PanelMockProps) => (
     <div
       data-testid='resizable-panel'
       data-default-size={defaultSize}
@@ -32,6 +27,11 @@ jest.mock('react-resizable-panels', () => ({
       data-onresize={onResize ? 'defined' : 'undefined'}
       style={style}
     >
+      {onResize && (
+        <button data-testid='resize-trigger' onClick={() => onResize({ asPercentage: 25 })}>
+          Resize
+        </button>
+      )}
       {children}
     </div>
   )
@@ -269,7 +269,7 @@ describe('LeftPanel', () => {
 
     it('debounces_save_operation_on_resize', async () => {
       // Given: コンポーネントがレンダリングされている
-      const { rerender } = render(
+      render(
         <LeftPanel>
           <div>Test Content</div>
         </LeftPanel>
@@ -278,28 +278,20 @@ describe('LeftPanel', () => {
       await waitFor(() => screen.getByTestId('resizable-panel'));
 
       // When: 短時間に複数回リサイズイベントが発生
-      const mockOnResize = jest.fn();
-      window.api.saveLeftPanelSize = mockOnResize;
+      const resizeTrigger = screen.getByTestId('resize-trigger');
+      fireEvent.click(resizeTrigger);
+      fireEvent.click(resizeTrigger);
 
-      // リサイズのシミュレーション（実際のPanelコンポーネントではないため、直接呼び出しはできない）
-      // この場合、デバウンス動作が実装されていることを確認
-
-      // 500ms未満の間隔でリサイズが発生する場合、保存は一度だけ実行される
+      // 500ms未満の間隔では保存されない
       jest.advanceTimersByTime(100);
-
-      // Then: 即座には保存されない（デバウンスされる）
-      expect(mockOnResize).not.toHaveBeenCalled();
+      expect(mockSaveLeftPanelSize).not.toHaveBeenCalled();
 
       // When: デバウンス時間が経過
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(400);
 
-      // 実際のリサイズイベントはモックされたPanelから呼ばれないため、
-      // ここではデバウンスロジックが存在することを確認
-      rerender(
-        <LeftPanel>
-          <div>Test Content</div>
-        </LeftPanel>
-      );
+      // Then: デバウンス完了後に保存が1回実行される
+      expect(mockSaveLeftPanelSize).toHaveBeenCalledTimes(1);
+      expect(mockSaveLeftPanelSize).toHaveBeenCalledWith(25);
     });
   });
 
@@ -318,13 +310,15 @@ describe('LeftPanel', () => {
 
       await waitFor(() => screen.getByTestId('resizable-panel'));
 
+      // When: リサイズイベントが発生
+      const resizeTrigger = screen.getByTestId('resize-trigger');
+      fireEvent.click(resizeTrigger);
+
       // When: コンポーネントがアンマウントされる
       unmount();
 
-      // Then: タイムアウトがクリアされる（エラーが発生しない）
+      // Then: タイムアウトがクリアされる（アンマウント後に保存処理が実行されない）
       jest.advanceTimersByTime(1000);
-
-      // アンマウント後に保存処理が実行されないことを確認
       expect(mockSaveLeftPanelSize).not.toHaveBeenCalled();
     });
   });

--- a/src/renderer/components/Layout/__tests__/LeftPanel.test.tsx
+++ b/src/renderer/components/Layout/__tests__/LeftPanel.test.tsx
@@ -1,0 +1,468 @@
+/**
+ * LeftPanelコンポーネントのテスト
+ *
+ * パネルのリサイズ、サイズの保存/読み込み機能を検証する
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import LeftPanel from '../LeftPanel';
+
+// react-resizable-panelsのモック
+jest.mock('react-resizable-panels', () => ({
+  Panel: ({
+    children,
+    onResize,
+    defaultSize,
+    minSize,
+    maxSize,
+    style
+  }: {
+    children: React.ReactNode;
+    onResize?: () => void;
+    defaultSize?: string;
+    minSize?: string;
+    maxSize?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <div
+      data-testid='resizable-panel'
+      data-default-size={defaultSize}
+      data-min-size={minSize}
+      data-max-size={maxSize}
+      data-onresize={onResize ? 'defined' : 'undefined'}
+      style={style}
+    >
+      {children}
+    </div>
+  )
+}));
+
+describe('LeftPanel', () => {
+  let mockGetLeftPanelSize: jest.Mock;
+  let mockSaveLeftPanelSize: jest.Mock;
+
+  // Unhandled promise rejectionのグローバルハンドラ
+  const originalProcessListeners = process.listeners('unhandledRejection');
+
+  beforeAll(() => {
+    // テスト中のunhandled rejectionを抑制
+    process.removeAllListeners('unhandledRejection');
+  });
+
+  afterAll(() => {
+    // 元のリスナーを復元
+    originalProcessListeners.forEach(listener => {
+      process.on('unhandledRejection', listener);
+    });
+  });
+
+  beforeEach(() => {
+    // Given: window.apiのモックをリセット
+    mockGetLeftPanelSize = jest.fn().mockResolvedValue(20);
+    mockSaveLeftPanelSize = jest.fn().mockResolvedValue(undefined);
+
+    window.api.getLeftPanelSize = mockGetLeftPanelSize;
+    window.api.saveLeftPanelSize = mockSaveLeftPanelSize;
+
+    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  describe('initial rendering', () => {
+    it('does_not_render_panel_before_size_is_loaded', () => {
+      // Given: サイズの取得が保留中
+      mockGetLeftPanelSize.mockReturnValue(new Promise(() => {}));
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: パネルがレンダリングされない
+      expect(screen.queryByTestId('resizable-panel')).not.toBeInTheDocument();
+    });
+
+    it('renders_panel_with_saved_size_when_available', async () => {
+      // Given: 保存されたサイズが25%
+      mockGetLeftPanelSize.mockResolvedValue(25);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 保存されたサイズでパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel).toBeInTheDocument();
+        expect(panel.getAttribute('data-default-size')).toBe('25%');
+      });
+    });
+
+    it('renders_panel_with_default_size_when_no_saved_size_exists', async () => {
+      // Given: 保存されたサイズがない
+      mockGetLeftPanelSize.mockResolvedValue(null);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: デフォルトサイズ（20%）でパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel).toBeInTheDocument();
+        expect(panel.getAttribute('data-default-size')).toBe('20%');
+      });
+    });
+
+    it('renders_panel_with_default_size_when_saved_size_is_undefined', async () => {
+      // Given: 保存されたサイズがundefined
+      mockGetLeftPanelSize.mockResolvedValue(undefined);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: デフォルトサイズ（20%）でパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel).toBeInTheDocument();
+        expect(panel.getAttribute('data-default-size')).toBe('20%');
+      });
+    });
+  });
+
+  describe('panel constraints', () => {
+    beforeEach(() => {
+      mockGetLeftPanelSize.mockResolvedValue(20);
+    });
+
+    it('sets_minimum_size_to_10_percent', async () => {
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 最小サイズが10%に設定される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-min-size')).toBe('10%');
+      });
+    });
+
+    it('sets_maximum_size_to_30_percent', async () => {
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 最大サイズが30%に設定される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-max-size')).toBe('30%');
+      });
+    });
+  });
+
+  describe('panel styling', () => {
+    beforeEach(() => {
+      mockGetLeftPanelSize.mockResolvedValue(20);
+    });
+
+    it('applies_correct_overflow_styles', async () => {
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: オーバーフロースタイルが正しく設定される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        const style = panel.style;
+        expect(style.overflowY).toBe('auto');
+        expect(style.overflowX).toBe('hidden');
+      });
+    });
+  });
+
+  describe('content rendering', () => {
+    beforeEach(() => {
+      mockGetLeftPanelSize.mockResolvedValue(20);
+    });
+
+    it('renders_children_content_after_initialization', async () => {
+      // When: 子要素を含むコンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div data-testid='child-content'>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 子要素がレンダリングされる
+      await waitFor(() => {
+        expect(screen.getByTestId('child-content')).toBeInTheDocument();
+        expect(screen.getByText('Test Content')).toBeInTheDocument();
+      });
+    });
+
+    it('renders_multiple_children', async () => {
+      // When: 複数の子要素を含むコンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>First Child</div>
+          <div>Second Child</div>
+          <div>Third Child</div>
+        </LeftPanel>
+      );
+
+      // Then: すべての子要素がレンダリングされる
+      await waitFor(() => {
+        expect(screen.getByText('First Child')).toBeInTheDocument();
+        expect(screen.getByText('Second Child')).toBeInTheDocument();
+        expect(screen.getByText('Third Child')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('resize handling', () => {
+    beforeEach(() => {
+      mockGetLeftPanelSize.mockResolvedValue(20);
+      mockSaveLeftPanelSize.mockResolvedValue(undefined);
+    });
+
+    it('provides_onResize_handler_to_panel', async () => {
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: onResizeハンドラーが設定される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-onresize')).toBe('defined');
+      });
+    });
+
+    it('debounces_save_operation_on_resize', async () => {
+      // Given: コンポーネントがレンダリングされている
+      const { rerender } = render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      await waitFor(() => screen.getByTestId('resizable-panel'));
+
+      // When: 短時間に複数回リサイズイベントが発生
+      const mockOnResize = jest.fn();
+      window.api.saveLeftPanelSize = mockOnResize;
+
+      // リサイズのシミュレーション（実際のPanelコンポーネントではないため、直接呼び出しはできない）
+      // この場合、デバウンス動作が実装されていることを確認
+
+      // 500ms未満の間隔でリサイズが発生する場合、保存は一度だけ実行される
+      jest.advanceTimersByTime(100);
+
+      // Then: 即座には保存されない（デバウンスされる）
+      expect(mockOnResize).not.toHaveBeenCalled();
+
+      // When: デバウンス時間が経過
+      jest.advanceTimersByTime(500);
+
+      // 実際のリサイズイベントはモックされたPanelから呼ばれないため、
+      // ここではデバウンスロジックが存在することを確認
+      rerender(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    beforeEach(() => {
+      mockGetLeftPanelSize.mockResolvedValue(20);
+    });
+
+    it('clears_pending_timeout_on_unmount', async () => {
+      // Given: コンポーネントがレンダリングされている
+      const { unmount } = render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      await waitFor(() => screen.getByTestId('resizable-panel'));
+
+      // When: コンポーネントがアンマウントされる
+      unmount();
+
+      // Then: タイムアウトがクリアされる（エラーが発生しない）
+      jest.advanceTimersByTime(1000);
+
+      // アンマウント後に保存処理が実行されないことを確認
+      expect(mockSaveLeftPanelSize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('API interaction', () => {
+    it('calls_getLeftPanelSize_on_mount', async () => {
+      // Given: APIモックが設定されている
+      mockGetLeftPanelSize.mockResolvedValue(20);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: getLeftPanelSizeが呼ばれる
+      await waitFor(() => {
+        expect(mockGetLeftPanelSize).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('handles_null_return_value_as_default', async () => {
+      // Given: APIがnullを返す
+      mockGetLeftPanelSize.mockResolvedValue(null);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: デフォルトサイズが使用される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('20%');
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      // すべてのエッジケーステストでデフォルトの成功応答を設定
+      mockGetLeftPanelSize.mockResolvedValue(20);
+    });
+
+    it('handles_zero_size_value', async () => {
+      // Given: 保存されたサイズが0
+      mockGetLeftPanelSize.mockResolvedValue(0);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 0%でパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('0%');
+      });
+    });
+
+    it('handles_boundary_size_values', async () => {
+      // Given: 保存されたサイズが境界値（10%）
+      mockGetLeftPanelSize.mockResolvedValue(10);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 10%でパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('10%');
+      });
+    });
+
+    it('handles_maximum_boundary_size', async () => {
+      // Given: 保存されたサイズが境界値（30%）
+      mockGetLeftPanelSize.mockResolvedValue(30);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 30%でパネルがレンダリングされる
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('30%');
+      });
+    });
+  });
+
+  describe('size persistence integration', () => {
+    it('reads_size_from_storage_and_applies_it', async () => {
+      // Given: ストレージに22%が保存されている
+      mockGetLeftPanelSize.mockResolvedValue(22);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: 保存された値が読み込まれ、適用される
+      await waitFor(() => {
+        expect(mockGetLeftPanelSize).toHaveBeenCalledTimes(1);
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('22%');
+      });
+    });
+
+    it('falls_back_to_default_when_storage_returns_null', async () => {
+      // Given: ストレージが空
+      mockGetLeftPanelSize.mockResolvedValue(null);
+
+      // When: コンポーネントをレンダリング
+      render(
+        <LeftPanel>
+          <div>Test Content</div>
+        </LeftPanel>
+      );
+
+      // Then: デフォルト値が使用される
+      await waitFor(() => {
+        const panel = screen.getByTestId('resizable-panel');
+        expect(panel.getAttribute('data-default-size')).toBe('20%');
+      });
+    });
+  });
+});

--- a/src/shared/__tests__/LeftPanelSize.test.ts
+++ b/src/shared/__tests__/LeftPanelSize.test.ts
@@ -1,0 +1,170 @@
+import { LeftPanelSize } from '../domain/LeftPanelSize';
+
+describe('LeftPanelSize', () => {
+  describe('create', () => {
+    it('creates_with_a_value_within_valid_range', () => {
+      // Given
+      const value = 20;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(20);
+    });
+
+    it('creates_with_MIN_boundary_value', () => {
+      // Given
+      const value = LeftPanelSize.MIN;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(10);
+    });
+
+    it('creates_with_MAX_boundary_value', () => {
+      // Given
+      const value = LeftPanelSize.MAX;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(30);
+    });
+
+    it('creates_with_a_decimal_value_within_range', () => {
+      // Given
+      const value = 15.5;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(15.5);
+    });
+
+    it('clamps_to_MIN_when_value_is_below_range', () => {
+      // Given
+      const value = 5;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.MIN);
+    });
+
+    it('clamps_to_MIN_when_value_is_negative', () => {
+      // Given
+      const value = -100;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.MIN);
+    });
+
+    it('clamps_to_MAX_when_value_exceeds_range', () => {
+      // Given
+      const value = 50;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.MAX);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_NaN', () => {
+      // Given
+      const value = NaN;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_Infinity', () => {
+      // Given
+      const value = Infinity;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_negative_Infinity', () => {
+      // Given
+      const value = -Infinity;
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_a_string', () => {
+      // Given
+      const value = '20';
+
+      // When
+      const sut = LeftPanelSize.create(value);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_null', () => {
+      // When
+      const sut = LeftPanelSize.create(null);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_undefined', () => {
+      // When
+      const sut = LeftPanelSize.create(undefined);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+
+    it('falls_back_to_DEFAULT_when_value_is_a_boolean', () => {
+      // When
+      const sut = LeftPanelSize.create(true);
+
+      // Then
+      expect(sut.toPrimitive()).toBe(LeftPanelSize.DEFAULT);
+    });
+  });
+
+  describe('equals', () => {
+    it('returns_true_for_equal_values', () => {
+      // Given
+      const a = LeftPanelSize.create(20);
+      const b = LeftPanelSize.create(20);
+
+      // When & Then
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('returns_false_for_different_values', () => {
+      // Given
+      const a = LeftPanelSize.create(15);
+      const b = LeftPanelSize.create(25);
+
+      // When & Then
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -4,5 +4,6 @@ export const ICON_PATH = path.join(__dirname, 'assets', 'Aegis.ico');
 
 export const STORE_KEY_TREE_VIEW_EXPANDED_ITEMS = 'treeViewExpandedItems';
 export const STORE_KEY_TREE_VIEW_SELECTED_ITEM_ID = 'treeViewSelectedItemId';
+export const STORE_KEY_LEFT_PANEL_SIZE = 'leftPanelSize';
 
 export const CLOSE_DIALOG_ACTION_URL = 'http://close-dialog/';

--- a/src/shared/domain/LeftPanelSize.ts
+++ b/src/shared/domain/LeftPanelSize.ts
@@ -1,0 +1,49 @@
+/**
+ * 左パネルサイズを表す Value Object（パーセンテージ）。
+ *
+ * Main / Renderer 両プロセスから参照可能な共有ドメインモデル。
+ *
+ * 不変条件:
+ * - 有限の数値であること（NaN, Infinity は不可）
+ * - MIN 以上 MAX 以下の範囲に収まること
+ *
+ * バリデーション失敗時は範囲内にクランプ（丸め）する。
+ * 数値以外の値が渡された場合はデフォルト値にフォールバックする。
+ */
+export class LeftPanelSize {
+  /** 左パネルの最小サイズ (%) */
+  static readonly MIN = 10;
+
+  /** 左パネルの最大サイズ (%) */
+  static readonly MAX = 30;
+
+  /** 左パネルのデフォルトサイズ (%) */
+  static readonly DEFAULT = 20;
+
+  private constructor(private readonly value: number) {}
+
+  /**
+   * 任意の値から LeftPanelSize を生成する。
+   *
+   * - 数値でない / 有限でない場合 → デフォルト値
+   * - MIN 未満の場合 → MIN にクランプ
+   * - MAX 超過の場合 → MAX にクランプ
+   */
+  static create(value: unknown): LeftPanelSize {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return new LeftPanelSize(LeftPanelSize.DEFAULT);
+    }
+
+    const clamped = Math.max(LeftPanelSize.MIN, Math.min(LeftPanelSize.MAX, value));
+    return new LeftPanelSize(clamped);
+  }
+
+  /** ストア保存用のプリミティブ値を返す */
+  toPrimitive(): number {
+    return this.value;
+  }
+
+  equals(other: LeftPanelSize): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/shared/types/ElectronAPI.ts
+++ b/src/shared/types/ElectronAPI.ts
@@ -18,6 +18,8 @@ export interface ElectronAPI {
   getTreeViewSelectedItemId(): Promise<string | undefined>;
   saveTreeViewSelectedItemId(itemId: string | null): Promise<void>;
   saveTreeViewExpandedItems(expandedItemIds: string[]): Promise<void>;
+  saveLeftPanelSize(size: number): Promise<void>;
+  getLeftPanelSize(): Promise<number | undefined>;
 
   // Event listeners
   onSaveData(callback: VoidCallback): IpcEventHandler;

--- a/src/shared/types/ElectronAPI.ts
+++ b/src/shared/types/ElectronAPI.ts
@@ -19,7 +19,7 @@ export interface ElectronAPI {
   saveTreeViewSelectedItemId(itemId: string | null): Promise<void>;
   saveTreeViewExpandedItems(expandedItemIds: string[]): Promise<void>;
   saveLeftPanelSize(size: number): Promise<void>;
-  getLeftPanelSize(): Promise<number | undefined>;
+  getLeftPanelSize(): Promise<number>;
 
   // Event listeners
   onSaveData(callback: VoidCallback): IpcEventHandler;


### PR DESCRIPTION
## Summary
Extracted LeftPanel component from App.tsx and added panel size persistence functionality.

## Background
The left panel layout logic was embedded directly in App.tsx, making it less maintainable. This PR extracts it into a dedicated component and adds the ability to persist panel size across sessions.

## Changes
- (Code) Created LeftPanel component with Panel wrapper for tree view
- (Code) Added IPC handlers and APIs for left panel size persistence
- (Test) Added unit tests for LeftPanel component
- (Config) Updated ESLint and Jest configurations

## Implementation Notes
Implemented a reusable LeftPanel component that encapsulates resizable panel logic. Added Electron IPC communication layer to save and restore panel size using electron-store.

## Impact & Risks
Low risk refactoring with no behavior changes to existing functionality. Size persistence is a new feature that enhances UX by maintaining user preferences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a resizable left panel around the item tree with size constraints and improved scrolling.
  - Automatically saves and restores the left panel size when reopening the app.
- **Tests**
  - Added coverage for sizing rules, persistence, debounced saving, and cleanup.
- **Chores**
  - Excluded release files from test discovery.
  - Updated linting configuration to recognize timer globals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->