### PR TITLE
chore: Migrate Git hooks from Husky to Lefthook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,8 +54,7 @@ updates:
           - "@typescript-eslint/*"
           - "prettier"
           - "@trivago/prettier-plugin-sort-imports"
-          - "lint-staged"
-          - "husky"
+          - "lefthook"
       # TypeScript関連パッケージをまとめる
       typescript-stack:
         patterns:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 # VSCode settings
 .vscode/settings.json
+
+coverage

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-lint-staged

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Before pushing changes, ensure the codebase is properly formatted and linted:
 npm run lint-and-format
 ```
 
-#### Git Hooks (Husky)
+#### Git Hooks (Lefthook)
 
-This project uses [Husky](https://typicode.github.io/husky/) and `lint-staged` to enforce code quality before commits.
-When you run `npm install`, the Husky hooks are automatically set up (`npm run prepare`).
+This project uses [Lefthook](https://github.com/evilmartians/lefthook) to enforce code quality before commits.
+When you run `npm install`, the Lefthook hooks are automatically set up (`npm run prepare`).
 
-On every `git commit`, Husky will trigger a pre-commit hook that runs Prettier and ESLint on your staged files, ensuring formatting and linting rules are met. If linting fails, the commit will be aborted.
+On every `git commit`, Lefthook will trigger a pre-commit hook that runs Prettier and ESLint on your staged files, ensuring formatting and linting rules are met. If linting fails, the commit will be aborted.
 
 #### CI/CD (GitHub Actions)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,5 @@
+glob_matcher: doublestar
+
 pre-commit:
   parallel: true
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint-and-format-ts:
+      glob: "src/**/*.{ts,tsx}"
+      run: npx eslint --fix {staged_files} && npx prettier --write {staged_files}
+      stage_fixed: true
+    format-other:
+      glob: "src/**/*.{js,json,css,md}"
+      run: npx prettier --write {staged_files}
+      stage_fixed: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,14 +56,13 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "html-webpack-plugin": "^5.5.3",
-        "husky": "^9.1.7",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.3.0",
         "jest-fixed-jsdom": "^0.0.11",
         "jest-transform-stub": "^2.0.0",
         "jest-util": "^30.2.0",
-        "lint-staged": "^17.0.3",
+        "lefthook": "^2.1.10",
         "mini-css-extract-plugin": "^2.7.6",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.6.2",
@@ -8953,22 +8952,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -11179,6 +11162,169 @@
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "license": "MIT"
     },
+    "node_modules/lefthook": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.10.tgz",
+      "integrity": "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.10",
+        "lefthook-darwin-x64": "2.1.10",
+        "lefthook-freebsd-arm64": "2.1.10",
+        "lefthook-freebsd-x64": "2.1.10",
+        "lefthook-linux-arm64": "2.1.10",
+        "lefthook-linux-x64": "2.1.10",
+        "lefthook-openbsd-arm64": "2.1.10",
+        "lefthook-openbsd-x64": "2.1.10",
+        "lefthook-windows-arm64": "2.1.10",
+        "lefthook-windows-x64": "2.1.10"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.10.tgz",
+      "integrity": "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.10.tgz",
+      "integrity": "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.10.tgz",
+      "integrity": "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.10.tgz",
+      "integrity": "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.10.tgz",
+      "integrity": "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.10.tgz",
+      "integrity": "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.10.tgz",
+      "integrity": "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.10.tgz",
+      "integrity": "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.10.tgz",
+      "integrity": "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.10.tgz",
+      "integrity": "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11208,47 +11354,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
-    },
-    "node_modules/lint-staged": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
-      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^4.0.5",
-        "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
-      },
-      "bin": {
-        "lint-staged": "bin/lint-staged.js"
-      },
-      "engines": {
-        "node": ">=22.22.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
-      },
-      "optionalDependencies": {
-        "yaml": "^2.9.0"
-      }
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -14292,16 +14397,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -15032,16 +15127,6 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "dist/main.js",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "lefthook install",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,json,css,md}\"",
@@ -30,15 +30,6 @@
     "dev:electron": "wait-on dist/main.js dist/index.html && electronmon .",
     "package": "electron-packager ./dist PasswordManager --icon=./dist/assets/Aegis.ico --overwrite --out=release",
     "release": "npm run build && electron-builder --win nsis --publish never"
-  },
-  "lint-staged": {
-    "src/**/*.{ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "src/**/*.{js,json,css,md}": [
-      "prettier --write"
-    ]
   },
   "electronmon": {
     "patterns": [
@@ -93,14 +84,13 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "html-webpack-plugin": "^5.5.3",
-    "husky": "^9.1.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.3.0",
     "jest-fixed-jsdom": "^0.0.11",
     "jest-transform-stub": "^2.0.0",
     "jest-util": "^30.2.0",
-    "lint-staged": "^17.0.3",
+    "lefthook": "^2.1.10",
     "mini-css-extract-plugin": "^2.7.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Summary
Migrated Git hooks tool from Husky + lint-staged to Lefthook for faster and simpler hook management.

## Changes
- **Dependency / Configuration**: Replaced `husky` and `lint-staged` with `lefthook` in `package.json`
- **Hook Definition**: Added `lefthook.yml` with `pre-commit` hook for ESLint and Prettier
- **Cleanup**: Removed deprecated `.husky/pre-commit`
- **Documentation**: Updated Git hooks section in `README.md` to reference Lefthook commands
- **Dependabot**: Updated `.github/dependabot.yml` `lint-stack` group to include `@evilmartians/lefthook`
- **Git Ignore**: Added `coverage` directory to `.gitignore`

## Verification
- Verified Lefthook pre-commit hook runs properly with `npx lefthook run pre-commit`
- Verified tests, lint, and format checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s automated code-quality workflow.
  * Added automatic formatting and linting checks for supported file types.
  * Improved handling of generated coverage files.
  * Replaced the previous commit-check tooling with a streamlined alternative.

* **Documentation**
  * Updated setup and contribution guidance to reflect the revised workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->